### PR TITLE
Update ADC -- PDN_SYSREF: 0x0

### DIFF
--- a/defaults/2019_06_04_Dual_Band_AMC_Config.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config.yml
@@ -525,7 +525,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0x12
+          SysrefDelay: 0x0
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/2019_06_04_Dual_Band_AMC_Config.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config.yml
@@ -432,7 +432,7 @@ AMCc:
           ADC[:]:
             enable: True
             SYNCB_POL: 0x1
-            PDN_SYSREF: 0x1
+            PDN_SYSREF: 0x0
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/2019_06_04_Dual_Band_AMC_Config.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config.yml
@@ -9,16 +9,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000000000000
             StartAddr[1]: 0x0000000010000000
-            StartAddr[2]: 0x0000000020000000
-            StartAddr[3]: 0x0000000030000000
             EndAddr[0]:   0x0000000000004000
             EndAddr[1]:   0x0000000010004000
-            EndAddr[2]:   0x0000000020004000
-            EndAddr[3]:   0x0000000030004000
             Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
             Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[2]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[3]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -28,16 +22,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000040000000
             StartAddr[1]: 0x0000000050000000
-            StartAddr[2]: 0x0000000060000000
-            StartAddr[3]: 0x0000000070000000
             EndAddr[0]:   0x0000000040004000
             EndAddr[1]:   0x0000000050004000
-            EndAddr[2]:   0x0000000060004000
-            EndAddr[3]:   0x0000000070004000
             Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
             Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[2]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[3]: 0x0 # Disabling 2nd DAQ MUX path
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -241,8 +229,8 @@ AMCc:
             LmkReg_0x0137: 0x16
             LmkReg_0x0138: 0x00
             LmkReg_0x0139: 0x03
-            LmkReg_0x013A: 0x04
-            LmkReg_0x013B: 0x00
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
             LmkReg_0x013C: 0x00
             LmkReg_0x013D: 0x08
             LmkReg_0x013E: 0x03
@@ -433,6 +421,9 @@ AMCc:
             enable: True
             SYNCB_POL: 0x1
             PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x7
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
@@ -534,7 +525,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0xB
+          SysrefDelay: 0x12
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/2019_06_04_Dual_Band_AMC_Config.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config.yml
@@ -423,7 +423,7 @@ AMCc:
             PDN_SYSREF: 0x0
             SYSREF_DEL_EN: 0x1
             SYSREF_DEL_HI: 0x0
-            SYSREF_DEL_LO: 0x7
+            SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
@@ -525,7 +525,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0x12
+          SysrefDelay: 0x0
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
@@ -432,7 +432,7 @@ AMCc:
           ADC[:]:
             enable: True
             SYNCB_POL: 0x1
-            PDN_SYSREF: 0x1
+            PDN_SYSREF: 0x0
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
@@ -9,16 +9,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000000000000
             StartAddr[1]: 0x0000000010000000
-            StartAddr[2]: 0x0000000020000000
-            StartAddr[3]: 0x0000000030000000
             EndAddr[0]:   0x0000000000004000
             EndAddr[1]:   0x0000000010004000
-            EndAddr[2]:   0x0000000020004000
-            EndAddr[3]:   0x0000000030004000
             Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
             Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[2]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[3]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -28,16 +22,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000040000000
             StartAddr[1]: 0x0000000050000000
-            StartAddr[2]: 0x0000000060000000
-            StartAddr[3]: 0x0000000070000000
             EndAddr[0]:   0x0000000040004000
             EndAddr[1]:   0x0000000050004000
-            EndAddr[2]:   0x0000000060004000
-            EndAddr[3]:   0x0000000070004000
             Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
             Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[2]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[3]: 0x0 # Disabling 2nd DAQ MUX path
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -241,8 +229,8 @@ AMCc:
             LmkReg_0x0137: 0x16
             LmkReg_0x0138: 0x00
             LmkReg_0x0139: 0x03
-            LmkReg_0x013A: 0x04
-            LmkReg_0x013B: 0x00
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
             LmkReg_0x013C: 0x00
             LmkReg_0x013D: 0x08
             LmkReg_0x013E: 0x03
@@ -433,6 +421,9 @@ AMCc:
             enable: True
             SYNCB_POL: 0x1
             PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x7
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
@@ -534,7 +525,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0xB
+          SysrefDelay: 0x12
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
@@ -423,7 +423,7 @@ AMCc:
             PDN_SYSREF: 0x0
             SYSREF_DEL_EN: 0x1
             SYSREF_DEL_HI: 0x0
-            SYSREF_DEL_LO: 0x7
+            SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
@@ -525,7 +525,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0x12
+          SysrefDelay: 0x0
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
@@ -432,7 +432,7 @@ AMCc:
           ADC[:]:
             enable: True
             SYNCB_POL: 0x1
-            PDN_SYSREF: 0x1
+            PDN_SYSREF: 0x0
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
@@ -9,16 +9,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000000000000
             StartAddr[1]: 0x0000000010000000
-            StartAddr[2]: 0x0000000020000000
-            StartAddr[3]: 0x0000000030000000
             EndAddr[0]:   0x0000000000004000
             EndAddr[1]:   0x0000000010004000
-            EndAddr[2]:   0x0000000020004000
-            EndAddr[3]:   0x0000000030004000
             Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
             Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[2]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[3]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -28,16 +22,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000040000000
             StartAddr[1]: 0x0000000050000000
-            StartAddr[2]: 0x0000000060000000
-            StartAddr[3]: 0x0000000070000000
             EndAddr[0]:   0x0000000040004000
             EndAddr[1]:   0x0000000050004000
-            EndAddr[2]:   0x0000000060004000
-            EndAddr[3]:   0x0000000070004000
             Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
             Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[2]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[3]: 0x0 # Disabling 2nd DAQ MUX path
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -241,8 +229,8 @@ AMCc:
             LmkReg_0x0137: 0x16
             LmkReg_0x0138: 0x00
             LmkReg_0x0139: 0x03
-            LmkReg_0x013A: 0x04
-            LmkReg_0x013B: 0x00
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
             LmkReg_0x013C: 0x00
             LmkReg_0x013D: 0x08
             LmkReg_0x013E: 0x03
@@ -433,6 +421,9 @@ AMCc:
             enable: True
             SYNCB_POL: 0x1
             PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x7
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
@@ -534,7 +525,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0xB
+          SysrefDelay: 0x12
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
@@ -423,7 +423,7 @@ AMCc:
             PDN_SYSREF: 0x0
             SYSREF_DEL_EN: 0x1
             SYSREF_DEL_HI: 0x0
-            SYSREF_DEL_LO: 0x7
+            SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_hbonly_c02_bay0.yml
+++ b/defaults/defaults_hbonly_c02_bay0.yml
@@ -368,7 +368,7 @@ AMCc:
           ADC[:]:
             enable: True
             SYNCB_POL: 0x1
-            PDN_SYSREF: 0x1
+            PDN_SYSREF: 0x0
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_hbonly_c02_bay0.yml
+++ b/defaults/defaults_hbonly_c02_bay0.yml
@@ -452,7 +452,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0x12
+          SysrefDelay: 0x0
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_hbonly_c02_bay0.yml
+++ b/defaults/defaults_hbonly_c02_bay0.yml
@@ -9,16 +9,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000000000000
             StartAddr[1]: 0x0000000010000000
-            StartAddr[2]: 0x0000000020000000
-            StartAddr[3]: 0x0000000030000000
             EndAddr[0]:   0x0000000000004000
             EndAddr[1]:   0x0000000010004000
-            EndAddr[2]:   0x0000000020004000
-            EndAddr[3]:   0x0000000030004000
             Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
             Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[2]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[3]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -28,16 +22,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000040000000
             StartAddr[1]: 0x0000000050000000
-            StartAddr[2]: 0x0000000060000000
-            StartAddr[3]: 0x0000000070000000
             EndAddr[0]:   0x0000000040004000
             EndAddr[1]:   0x0000000050004000
-            EndAddr[2]:   0x0000000060004000
-            EndAddr[3]:   0x0000000070004000
             Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
             Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[2]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[3]: 0x0 # Disabling 2nd DAQ MUX path
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -177,8 +165,8 @@ AMCc:
             LmkReg_0x0137: 0x16
             LmkReg_0x0138: 0x00
             LmkReg_0x0139: 0x03
-            LmkReg_0x013A: 0x04
-            LmkReg_0x013B: 0x00
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
             LmkReg_0x013C: 0x00
             LmkReg_0x013D: 0x08
             LmkReg_0x013E: 0x03
@@ -369,6 +357,9 @@ AMCc:
             enable: True
             SYNCB_POL: 0x1
             PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x7
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
@@ -461,7 +452,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0xB
+          SysrefDelay: 0x12
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_hbonly_c02_bay0.yml
+++ b/defaults/defaults_hbonly_c02_bay0.yml
@@ -359,7 +359,7 @@ AMCc:
             PDN_SYSREF: 0x0
             SYSREF_DEL_EN: 0x1
             SYSREF_DEL_HI: 0x0
-            SYSREF_DEL_LO: 0x7
+            SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_hbonly_c03_bay0.yml
+++ b/defaults/defaults_hbonly_c03_bay0.yml
@@ -9,16 +9,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000000000000
             StartAddr[1]: 0x0000000010000000
-            StartAddr[2]: 0x0000000020000000
-            StartAddr[3]: 0x0000000030000000
             EndAddr[0]:   0x0000000000004000
             EndAddr[1]:   0x0000000010004000
-            EndAddr[2]:   0x0000000020004000
-            EndAddr[3]:   0x0000000030004000
             Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
             Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[2]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[3]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -28,16 +22,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000040000000
             StartAddr[1]: 0x0000000050000000
-            StartAddr[2]: 0x0000000060000000
-            StartAddr[3]: 0x0000000070000000
             EndAddr[0]:   0x0000000040004000
             EndAddr[1]:   0x0000000050004000
-            EndAddr[2]:   0x0000000060004000
-            EndAddr[3]:   0x0000000070004000
             Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
             Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[2]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[3]: 0x0 # Disabling 2nd DAQ MUX path
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -178,8 +166,8 @@ AMCc:
             LmkReg_0x0137: 0x16
             LmkReg_0x0138: 0x00
             LmkReg_0x0139: 0x03
-            LmkReg_0x013A: 0x04
-            LmkReg_0x013B: 0x00
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
             LmkReg_0x013C: 0x00
             LmkReg_0x013D: 0x08
             LmkReg_0x013E: 0x03
@@ -370,6 +358,9 @@ AMCc:
             enable: True
             SYNCB_POL: 0x1
             PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x7
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
@@ -462,7 +453,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0xB
+          SysrefDelay: 0x12
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_hbonly_c03_bay0.yml
+++ b/defaults/defaults_hbonly_c03_bay0.yml
@@ -360,7 +360,7 @@ AMCc:
             PDN_SYSREF: 0x0
             SYSREF_DEL_EN: 0x1
             SYSREF_DEL_HI: 0x0
-            SYSREF_DEL_LO: 0x7
+            SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_hbonly_c03_bay0.yml
+++ b/defaults/defaults_hbonly_c03_bay0.yml
@@ -453,7 +453,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0x12
+          SysrefDelay: 0x0
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_hbonly_c03_bay0.yml
+++ b/defaults/defaults_hbonly_c03_bay0.yml
@@ -369,7 +369,7 @@ AMCc:
           ADC[:]:
             enable: True
             SYNCB_POL: 0x1
-            PDN_SYSREF: 0x1
+            PDN_SYSREF: 0x0
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_keck2019_swh_20190116.yml
+++ b/defaults/defaults_keck2019_swh_20190116.yml
@@ -9,16 +9,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000000000000
             StartAddr[1]: 0x0000000010000000
-            StartAddr[2]: 0x0000000020000000
-            StartAddr[3]: 0x0000000030000000
             EndAddr[0]:   0x0000000000004000
             EndAddr[1]:   0x0000000010004000
-            EndAddr[2]:   0x0000000020004000
-            EndAddr[3]:   0x0000000030004000
             Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
             Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[2]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[3]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -28,16 +22,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000040000000
             StartAddr[1]: 0x0000000050000000
-            StartAddr[2]: 0x0000000060000000
-            StartAddr[3]: 0x0000000070000000
             EndAddr[0]:   0x0000000040004000
             EndAddr[1]:   0x0000000050004000
-            EndAddr[2]:   0x0000000060004000
-            EndAddr[3]:   0x0000000070004000
             Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
             Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[2]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[3]: 0x0 # Disabling 2nd DAQ MUX path
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -170,8 +158,8 @@ AMCc:
             LmkReg_0x0137: 0x16
             LmkReg_0x0138: 0x00
             LmkReg_0x0139: 0x03
-            LmkReg_0x013A: 0x04
-            LmkReg_0x013B: 0x00
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
             LmkReg_0x013C: 0x00
             LmkReg_0x013D: 0x08
             LmkReg_0x013E: 0x03
@@ -363,6 +351,9 @@ AMCc:
             enable: True
             SYNCB_POL: 0x1
             PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x7
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
@@ -461,7 +452,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0xB
+          SysrefDelay: 0x12
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_keck2019_swh_20190116.yml
+++ b/defaults/defaults_keck2019_swh_20190116.yml
@@ -362,7 +362,7 @@ AMCc:
           ADC[:]:
             enable: True
             SYNCB_POL: 0x1
-            PDN_SYSREF: 0x1
+            PDN_SYSREF: 0x0
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_keck2019_swh_20190116.yml
+++ b/defaults/defaults_keck2019_swh_20190116.yml
@@ -452,7 +452,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0x12
+          SysrefDelay: 0x0
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_keck2019_swh_20190116.yml
+++ b/defaults/defaults_keck2019_swh_20190116.yml
@@ -353,7 +353,7 @@ AMCc:
             PDN_SYSREF: 0x0
             SYSREF_DEL_EN: 0x1
             SYSREF_DEL_HI: 0x0
-            SYSREF_DEL_LO: 0x7
+            SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_lbonly_c02_bay0.yml
+++ b/defaults/defaults_lbonly_c02_bay0.yml
@@ -9,16 +9,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000000000000
             StartAddr[1]: 0x0000000010000000
-            StartAddr[2]: 0x0000000020000000
-            StartAddr[3]: 0x0000000030000000
             EndAddr[0]:   0x0000000000004000
             EndAddr[1]:   0x0000000010004000
-            EndAddr[2]:   0x0000000020004000
-            EndAddr[3]:   0x0000000030004000
             Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
             Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[2]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[3]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -28,16 +22,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000040000000
             StartAddr[1]: 0x0000000050000000
-            StartAddr[2]: 0x0000000060000000
-            StartAddr[3]: 0x0000000070000000
             EndAddr[0]:   0x0000000040004000
             EndAddr[1]:   0x0000000050004000
-            EndAddr[2]:   0x0000000060004000
-            EndAddr[3]:   0x0000000070004000
             Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
             Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[2]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[3]: 0x0 # Disabling 2nd DAQ MUX path
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -178,8 +166,8 @@ AMCc:
             LmkReg_0x0137: 0x16
             LmkReg_0x0138: 0x00
             LmkReg_0x0139: 0x03
-            LmkReg_0x013A: 0x04
-            LmkReg_0x013B: 0x00
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
             LmkReg_0x013C: 0x00
             LmkReg_0x013D: 0x08
             LmkReg_0x013E: 0x03
@@ -370,6 +358,9 @@ AMCc:
             enable: True
             SYNCB_POL: 0x1
             PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x7
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
@@ -462,7 +453,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0xB
+          SysrefDelay: 0x12
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_lbonly_c02_bay0.yml
+++ b/defaults/defaults_lbonly_c02_bay0.yml
@@ -360,7 +360,7 @@ AMCc:
             PDN_SYSREF: 0x0
             SYSREF_DEL_EN: 0x1
             SYSREF_DEL_HI: 0x0
-            SYSREF_DEL_LO: 0x7
+            SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_lbonly_c02_bay0.yml
+++ b/defaults/defaults_lbonly_c02_bay0.yml
@@ -453,7 +453,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0x12
+          SysrefDelay: 0x0
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_lbonly_c02_bay0.yml
+++ b/defaults/defaults_lbonly_c02_bay0.yml
@@ -369,7 +369,7 @@ AMCc:
           ADC[:]:
             enable: True
             SYNCB_POL: 0x1
-            PDN_SYSREF: 0x1
+            PDN_SYSREF: 0x0
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_lbonly_c03_bay0.yml
+++ b/defaults/defaults_lbonly_c03_bay0.yml
@@ -370,7 +370,7 @@ AMCc:
           ADC[:]:
             enable: True
             SYNCB_POL: 0x1
-            PDN_SYSREF: 0x1
+            PDN_SYSREF: 0x0
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)

--- a/defaults/defaults_lbonly_c03_bay0.yml
+++ b/defaults/defaults_lbonly_c03_bay0.yml
@@ -454,7 +454,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0x12
+          SysrefDelay: 0x0
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_lbonly_c03_bay0.yml
+++ b/defaults/defaults_lbonly_c03_bay0.yml
@@ -9,16 +9,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000000000000
             StartAddr[1]: 0x0000000010000000
-            StartAddr[2]: 0x0000000020000000
-            StartAddr[3]: 0x0000000030000000
             EndAddr[0]:   0x0000000000004000
             EndAddr[1]:   0x0000000010004000
-            EndAddr[2]:   0x0000000020004000
-            EndAddr[3]:   0x0000000030004000
             Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
             Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[2]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
-            Enabled[3]: 0x0 # Enabled:  Full rate only supports 2x channels of streaming
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -28,16 +22,10 @@ AMCc:
           WaveformEngineBuffers:
             StartAddr[0]: 0x0000000040000000
             StartAddr[1]: 0x0000000050000000
-            StartAddr[2]: 0x0000000060000000
-            StartAddr[3]: 0x0000000070000000
             EndAddr[0]:   0x0000000040004000
             EndAddr[1]:   0x0000000050004000
-            EndAddr[2]:   0x0000000060004000
-            EndAddr[3]:   0x0000000070004000
             Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
             Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[2]: 0x0 # Disabling 2nd DAQ MUX path
-            Enabled[3]: 0x0 # Disabling 2nd DAQ MUX path
             Mode[:]: DoneWhenFull
             Init[:]: 0x0
             SoftTrigger[:]: 0x0
@@ -179,8 +167,8 @@ AMCc:
             LmkReg_0x0137: 0x16
             LmkReg_0x0138: 0x00
             LmkReg_0x0139: 0x03
-            LmkReg_0x013A: 0x04
-            LmkReg_0x013B: 0x00
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
             LmkReg_0x013C: 0x00
             LmkReg_0x013D: 0x08
             LmkReg_0x013E: 0x03
@@ -371,6 +359,9 @@ AMCc:
             enable: True
             SYNCB_POL: 0x1
             PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x7
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
@@ -463,7 +454,7 @@ AMCc:
           InvertSync: Inverted
           ReplaceEnable: Enabled
           SubClass: 0x1
-          SysrefDelay: 0xB
+          SysrefDelay: 0x12
         JesdTx:
           Enable: 0x3CF # Both DAC channels
           #Enable: 0xF   # Only using DAC[0]

--- a/defaults/defaults_lbonly_c03_bay0.yml
+++ b/defaults/defaults_lbonly_c03_bay0.yml
@@ -361,7 +361,7 @@ AMCc:
             PDN_SYSREF: 0x0
             SYSREF_DEL_EN: 0x1
             SYSREF_DEL_HI: 0x0
-            SYSREF_DEL_LO: 0x7
+            SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)


### PR DESCRIPTION
This with new PyRogue (ADC) gets the JESD latency to integer steps of 614.4MHz.  Without this we see steps of 2457.6MHz steps.