### PR TITLE
Bug fix: DaqMuxV2 and DacSigGen were missing the '[:]'

### DIFF
--- a/defaults/2019_06_04_Dual_Band_AMC_Config.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config.yml
@@ -571,7 +571,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[0]: 'Ch7'
         InputMuxSel[1]: 'Ch6'
         FormatDataWidth[:]: 'D16-bit'
@@ -581,7 +581,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
@@ -571,7 +571,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[0]: 'Ch7'
         InputMuxSel[1]: 'Ch6'
         FormatDataWidth[:]: 'D16-bit'
@@ -581,7 +581,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_c02_LBx2.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_c02_LBx2.yml
@@ -570,7 +570,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[0]: 'Ch7'
         InputMuxSel[1]: 'Ch6'
         FormatDataWidth[:]: 'D16-bit'
@@ -580,7 +580,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_swapBays.yml
@@ -571,7 +571,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[0]: 'Ch7'
         InputMuxSel[1]: 'Ch6'
         FormatDataWidth[:]: 'D16-bit'
@@ -581,7 +581,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/defaults_hbonly_c02_bay0.yml
+++ b/defaults/defaults_hbonly_c02_bay0.yml
@@ -498,7 +498,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[:]: 'Disabled'
         FormatDataWidth[:]: 'D16-bit'
         FormatSign[:]: 'Unsigned'
@@ -507,7 +507,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/defaults_hbonly_c03_bay0.yml
+++ b/defaults/defaults_hbonly_c03_bay0.yml
@@ -499,7 +499,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[:]: 'Disabled'
         FormatDataWidth[:]: 'D16-bit'
         FormatSign[:]: 'Unsigned'
@@ -508,7 +508,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/defaults_keck2019_swh_20190116.yml
+++ b/defaults/defaults_keck2019_swh_20190116.yml
@@ -498,7 +498,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[0]: 'Ch7'
         InputMuxSel[1]: 'Ch6'
         FormatDataWidth[:]: 'D16-bit'
@@ -510,7 +510,7 @@ AMCc:
       DaqMuxV2[1]:
         TriggerHwAutoRearm: Disabled
         TriggerHwArm: '0x0'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/defaults_lbonly_c02_bay0.yml
+++ b/defaults/defaults_lbonly_c02_bay0.yml
@@ -499,7 +499,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[:]: 'Disabled'
         FormatDataWidth[:]: 'D16-bit'
         FormatSign[:]: 'Unsigned'
@@ -508,7 +508,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/defaults_lbonly_c03_bay0.yml
+++ b/defaults/defaults_lbonly_c03_bay0.yml
@@ -500,7 +500,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[:]: 'Disabled'
         FormatDataWidth[:]: 'D16-bit'
         FormatSign[:]: 'Unsigned'
@@ -509,7 +509,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format

--- a/defaults/defaults_tkid.yml
+++ b/defaults/defaults_tkid.yml
@@ -499,7 +499,7 @@ AMCc:
           # dataOutMux[:]: TestData
           # testOutMux[:]: SquareWave
           # #############################
-      DaqMuxV2:
+      DaqMuxV2[:]:
         InputMuxSel[:]: 'Disabled'
         FormatDataWidth[:]: 'D16-bit'
         FormatSign[:]: 'Unsigned'
@@ -508,7 +508,7 @@ AMCc:
         TriggerHwAutoRearm: 'Disabled'
         TriggerHwArm: '0x0'
         TriggerCascMask: 'Disabled'
-      DacSigGen:
+      DacSigGen[:]:
         EnableMask: 0x3   # Enable both channels
         ModeMask:   0x3   # Set both channels into 'Periodic Mode'
         SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format


### PR DESCRIPTION
https://jira.slac.stanford.edu/browse/ESCRYODET-554