### PR TITLE
Add defaults for 2x HB setup

### DIFF
--- a/defaults/defaults_c03_hb_hb.yml
+++ b/defaults/defaults_c03_hb_hb.yml
@@ -1,0 +1,534 @@
+AMCc:
+  FpgaTopLevel:
+    AmcCarrierCore:
+      AmcCarrierTiming:
+        TimingFrameRx:
+            RxPolarity: 0x0
+      AmcCarrierBsa:
+        BsaWaveformEngine[0]:
+          WaveformEngineBuffers:
+            StartAddr[0]: 0x0000000000000000
+            StartAddr[1]: 0x0000000010000000
+            EndAddr[0]:   0x0000000000004000
+            EndAddr[1]:   0x0000000010004000
+            Enabled[0]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
+            Enabled[1]: 0x1 # Enabled:  Full rate only supports 2x channels of streaming
+            Mode[:]: DoneWhenFull
+            Init[:]: 0x0
+            SoftTrigger[:]: 0x0
+            MsgDest[:]: Auto-Readout
+            FramesAfterTrigger[:]: 0x0
+        BsaWaveformEngine[1]:
+          WaveformEngineBuffers:
+            StartAddr[0]: 0x0000000040000000
+            StartAddr[1]: 0x0000000050000000
+            EndAddr[0]:   0x0000000040004000
+            EndAddr[1]:   0x0000000050004000
+            Enabled[0]: 0x0 # Disabling 2nd DAQ MUX path
+            Enabled[1]: 0x0 # Disabling 2nd DAQ MUX path
+            Mode[:]: DoneWhenFull
+            Init[:]: 0x0
+            SoftTrigger[:]: 0x0
+            MsgDest[:]: Auto-Readout
+            FramesAfterTrigger[:]: 0x0
+      AxiSy56040:
+        OutputConfig[0]: 0x0
+        OutputConfig[1]: 0x0
+        OutputConfig[2]: 0x1
+        OutputConfig[3]: 0x1    
+    AppTop:
+      AppCore:
+        RtmCryoDet:
+          HighCycle: 0x5
+          LowCycle: 0x5
+          LutCtrl:
+            Ctrl:
+              EnableCh: 0x0
+        MicrowaveMuxCore[:]:
+          enable: 'True'
+          PLL[0]:
+            # 5.5012 GHz
+            REG[0]:  0x000002C0
+            REG[1]:  0x0C4D5551
+            REG[2]:  0x40032
+            REG[3]:  0x00000003
+            REG[4]:  0x30008B84
+            REG[5]:  0x800025
+            REG[6]:  0x3502C476
+            REG[7]:  0x12000007
+            REG[8]:  0x102D0428
+            REG[9]:  0x34337CC9
+            REG[10]:  0x00C03FFA
+            REG[11]:  0x61300B
+            REG[12]:  0x0001041C
+          PLL[1]:
+            # 6.0012 GHz
+            REG[0]:  0x00000300
+            REG[1]:  0x0D680001
+            REG[2]:  0x0000C002
+            REG[3]:  0x00000003
+            REG[4]:  0x30008B84
+            REG[5]:  0x800025
+            REG[6]:  0x35028476
+            REG[7]:  0x12000007
+            REG[8]:  0x102D0428
+            REG[9]:  0x34337CC9
+            REG[10]:  0x00C03FFA
+            REG[11]:  0x61300B
+            REG[12]:  0x0001041C
+          PLL[2]:
+            # 7.9988 GHz 
+            REG[0]:  0x0200200
+            REG[1]:  0x08C15551
+            REG[2]:  0x40032
+            REG[3]:  0x00000003
+            REG[4]:  0x30008B84
+            REG[5]:  0x800025
+            REG[6]:  0x3503A836
+            REG[7]:  0x12000007
+            REG[8]:  0x102D0428
+            REG[9]:  0x34337CC9
+            REG[10]:  0x00C03FFA
+            REG[11]:  0x61300B
+            REG[12]:  0x0001041C
+          PLL[3]:
+            # 8.4988 GHz
+            REG[0]:  0x200220
+            REG[1]:  0x094EAAA1
+            REG[2]:  0x80032
+            REG[3]:  0x00000003
+            REG[4]:  0x30008B84
+            REG[5]:  0x00800025
+            REG[6]:  0x35038836
+            REG[7]:  0x12000007
+            REG[8]:  0x102D0428
+            REG[9]:  0x34337CC9
+            REG[10]:  0x00C03FFA
+            REG[11]:  0x61300B
+            REG[12]:  0x0001041C
+          DBG:
+            txSyncMask: 0x0    # Both DAC channels
+            #txSyncMask: 0x2  # Only using DAC[0]
+            # txSyncMask: 0x1  # Only using DAC[1]
+            dacSpiMode: 0x1 # 4-wire SPI DAC
+          LMK:
+            EnableSync: 0xFF
+            EnableSysRef: 0x3
+            SyncBit: 0x1
+            LmkReg_0x0100: 0x08
+            LmkReg_0x0101: 0x55
+            LmkReg_0x0103: 0x00
+            LmkReg_0x0104: 0x22
+            LmkReg_0x0105: 0x00
+            LmkReg_0x0106: 0x70
+            LmkReg_0x0107: 0x06
+            LmkReg_0x0108: 0x61
+            LmkReg_0x0109: 0x55
+            LmkReg_0x010B: 0x01
+            LmkReg_0x010C: 0x22
+            LmkReg_0x010D: 0x00
+            LmkReg_0x010E: 0x70
+            LmkReg_0x010F: 0x9E
+            LmkReg_0x0110: 0x61
+            LmkReg_0x0111: 0x55
+            LmkReg_0x0113: 0x01
+            LmkReg_0x0114: 0x22
+            LmkReg_0x0115: 0x00
+            LmkReg_0x0116: 0x70
+            LmkReg_0x0117: 0x9E
+            LmkReg_0x0118: 0x74
+            LmkReg_0x0119: 0x55
+            LmkReg_0x011B: 0x00
+            LmkReg_0x011C: 0x22
+            LmkReg_0x011D: 0x00
+            LmkReg_0x011E: 0x70
+            LmkReg_0x011F: 0x001
+            LmkReg_0x0120: 0x61
+            LmkReg_0x0121: 0x55
+            LmkReg_0x0123: 0x01
+            LmkReg_0x0124: 0x22
+            LmkReg_0x0125: 0x00
+            LmkReg_0x0126: 0x70
+            LmkReg_0x0127: 0x9E
+            LmkReg_0x0128: 0x61
+            LmkReg_0x0129: 0x55
+            LmkReg_0x012B: 0x01
+            LmkReg_0x012C: 0x22
+            LmkReg_0x012D: 0x00
+            LmkReg_0x012E: 0x70
+            LmkReg_0x012F: 0x9E
+            LmkReg_0x0130: 0x08
+            LmkReg_0x0131: 0x55
+            LmkReg_0x0133: 0x00
+            LmkReg_0x0134: 0x22
+            LmkReg_0x0135: 0x00
+            LmkReg_0x0136: 0x70
+            LmkReg_0x0137: 0x16
+            LmkReg_0x0138: 0x00
+            LmkReg_0x0139: 0x03
+            LmkReg_0x013A: 0x00
+            LmkReg_0x013B: 0x80
+            LmkReg_0x013C: 0x00
+            LmkReg_0x013D: 0x08
+            LmkReg_0x013E: 0x03
+            LmkReg_0x013F: 0x00
+            LmkReg_0x0140: 0x00
+            LmkReg_0x0141: 0x00
+            LmkReg_0x0142: 0x00
+            LmkReg_0x0143: 0x11
+            LmkReg_0x0144: 0xFF
+            LmkReg_0x0145: 0x7F
+            LmkReg_0x0146: 0x10
+            LmkReg_0x0147: 0x1A
+            LmkReg_0x0148: 0x02
+            LmkReg_0x0149: 0x42
+            LmkReg_0x014A: 0x33
+            LmkReg_0x014B: 0x16
+            LmkReg_0x014C: 0x00
+            LmkReg_0x014D: 0x00
+            LmkReg_0x014E: 0x00
+            LmkReg_0x014F: 0x7F
+            LmkReg_0x0150: 0x01
+            LmkReg_0x0151: 0x02
+            LmkReg_0x0152: 0x00
+            LmkReg_0x0153: 0x00
+            LmkReg_0x0154: 0x0A
+            LmkReg_0x0155: 0x00
+            LmkReg_0x0156: 0x0a
+            LmkReg_0x0157: 0x00
+            LmkReg_0x0158: 0x96
+            LmkReg_0x0159: 0x00
+            LmkReg_0x015A: 0x0A
+            LmkReg_0x015B: 0xD0
+            LmkReg_0x015C: 0x20
+            LmkReg_0x015D: 0x00
+            LmkReg_0x015E: 0x00
+            LmkReg_0x015F: 0x0B
+            LmkReg_0x0160: 0x00
+            LmkReg_0x0161: 0x01
+            LmkReg_0x0162: 0x84
+            LmkReg_0x0163: 0x00
+            LmkReg_0x0164: 0x00
+            LmkReg_0x0165: 0x05
+            LmkReg_0x0166: 0x00
+            LmkReg_0x0167: 0x00
+            LmkReg_0x0168: 0x05
+            LmkReg_0x0169: 0x59
+            LmkReg_0x016A: 0x20
+            LmkReg_0x017D: 0x33
+            LmkReg_0x017C: 0x15
+            LmkReg_0x0174: 0x00
+            LmkReg_0x0173: 0x00
+            LmkReg_0x0172: 0x02
+            LmkReg_0x0171: 0xAA
+            LmkReg_0x016E: 0x13
+            LmkReg_0x016D: 0x00
+            LmkReg_0x016C: 0x00
+            LmkReg_0x016B: 0x00
+          DAC[:]:
+            DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
+            DacReg[1]: 0x0003   
+            DacReg[2]: 0x20F2   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
+            DacReg[3]: 0xF300   
+            DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
+            DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[7]: 0x3800
+            DacReg[8]: 0x0000
+            DacReg[9]: 0x0000
+            DacReg[10]: 0x0000
+            DacReg[11]: 0x0000
+            DacReg[12]: 0x0400
+            DacReg[13]: 0x0400
+            DacReg[14]: 0x0400
+            DacReg[15]: 0x0400
+            DacReg[16]: 0x0000
+            DacReg[17]: 0x0000
+            DacReg[18]: 0x0000
+            DacReg[19]: 0x0000
+            DacReg[20]: 0x0000
+            DacReg[21]: 0x0000
+            DacReg[22]: 0x4e00  # This is the upper 16 bits of the NCO frequency for the DACAB path
+            DacReg[23]: 0x0000
+            DacReg[24]: 0x0000
+            DacReg[25]: 0x4e00  # This is the upper 16 bits of the NCO frequency for the DACCD path
+            DacReg[26]: 0x0025
+            DacReg[27]: 0x0000
+            DacReg[28]: 0x0000
+            DacReg[29]: 0x0000
+            DacReg[30]: 0x2222
+            DacReg[31]: 0x2220
+            DacReg[32]: 0x2022
+            DacReg[33]: 0x0000
+            DacReg[34]: 0x1B1B  # Sets where samples go from JESD.  Datapath D goes to DACD, Datapath C goes to DACC, DatapathB goes to DACB and DatapathA goes to DACA
+            #DacReg[34]: 0x4B1B  # Sets where samples go from JESD.  Datapath D goes to DACD, Datapath C goes to DACC, DatapathB goes to DACB and DatapathA goes to DACA
+            DacReg[35]: 0x01FF  # This routes the "sleep terminal signal"  we don't use this so, it doesn't matter.
+            DacReg[36]: 0x0030  # Use only the next sysref pulse.  Uros had it set to NOT use the sysref pulse
+            DacReg[37]: 0x4000  # DACCLK div 4 to get JESD clock Uros had DACCLK=JESDCLK
+            DacReg[38]: 0x0000
+            DacReg[39]: 0x0000
+            DacReg[40]: 0x0013
+            DacReg[41]: 0xffff
+            DacReg[42]: 0x0000
+            DacReg[43]: 0x0000
+            DacReg[44]: 0x0000
+            DacReg[45]: 0x0000
+            DacReg[46]: 0xffff
+            DacReg[47]: 0x0004
+            DacReg[48]: 0x0000
+            DacReg[49]: 0x1000
+            DacReg[50]: 0x0000
+            DacReg[51]: 0x0000
+            DacReg[52]: 0x0000
+            DacReg[53]: 0x0000
+            DacReg[54]: 0x0000
+            DacReg[55]: 0x0000
+            DacReg[56]: 0x0000
+            DacReg[57]: 0x0000
+            DacReg[58]: 0x0000
+            DacReg[59]: 0x1800  # Set's divide amount for SERDES PLL ref clock divider (looks like it's set to 3?)
+            DacReg[60]: 0x0028  # Set's PLL multiply factor - eval set to: 14
+            DacReg[61]: 0x00AD  # Fully adaptive equalizer, boost on
+            DacReg[62]: 0x0108  # JESD termination setting and rate.  Only difference is Uros had LOS enabled.
+            DacReg[63]: 0x0000  # Swaping on JESD polarity.  I don't think we have and DAC JESD lanes swapped.
+            DacReg[64]: 0x0000
+            DacReg[65]: 0x0000
+            DacReg[66]: 0x0000
+            DacReg[67]: 0x0000
+            DacReg[68]: 0x0000
+            DacReg[69]: 0x0000
+            DacReg[70]: 0x0044
+            DacReg[71]: 0x190a
+            DacReg[72]: 0x31c3
+            DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
+            DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
+            DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[77]: 0x0300  # Number of converters per link - 4
+            DacReg[78]: 0x0f2f  # Enable scrambler
+            DacReg[79]: 0x1c61
+            DacReg[80]: 0x0000
+            DacReg[81]: 0x0026  # sync_request_ena_link0
+            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[83]: 0x0000
+            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[86]: 0x0000
+            DacReg[87]: 0x0026  # sync_request_ena_link2
+            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[89]: 0x0000
+            DacReg[90]: 0x0026  # sync_request_ena_link3
+            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
+            DacReg[93]: 0x0000
+            DacReg[94]: 0x0000
+            DacReg[95]: 0x0123  # cross switch for JESDlanes, not sure we want this as it may depend on their board - this set up is serds0 to jesdlane4, serdes1 to jesdlane2, serdes2 to jesdlane1, serdes3 to jesdlane0
+            DacReg[96]: 0x5764  # More cross switching SD4 to JD7, SD6 to JD6, SD7 to JD5, SD5 to JD4
+            DacReg[97]: 0x0211
+            DacReg[98]: 0x0000
+            DacReg[99]: 0x0000
+            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[101]: 0x0 # write to clear alarms0
+            DacReg[102]: 0x0 # write to clear alarms0
+            DacReg[103]: 0x0 # write to clear alarms0
+            DacReg[104]: 0x0 # write to clear alarms0
+            DacReg[105]: 0x0 # write to clear alarms0
+            DacReg[106]: 0x0 # write to clear alarms0
+            DacReg[107]: 0x0 # write to clear alarms0
+            DacReg[108]: 0x0 # write to clear alarms0
+            DacReg[109]: 0x0 # write to clear alarms0
+            DacReg[110]: 0x0000
+            DacReg[111]: 0x0000
+            DacReg[112]: 0x0000
+            DacReg[113]: 0x0000
+            DacReg[114]: 0x0000
+            DacReg[115]: 0x0000
+            DacReg[116]: 0x0000
+            DacReg[117]: 0x0000
+            DacReg[118]: 0x0000
+            DacReg[119]: 0x0000
+            DacReg[120]: 0x0000
+            DacReg[121]: 0x0000
+            DacReg[122]: 0x0000
+            DacReg[123]: 0x0000
+            DacReg[124]: 0x0000
+            DacReg[125]: 0x0000
+            EnableTx: 0x1
+          ADC[:]:
+            enable: True
+            SYNCB_POL: 0x1
+            PDN_SYSREF: 0x0
+            SYSREF_DEL_EN: 0x1
+            SYSREF_DEL_HI: 0x0
+            SYSREF_DEL_LO: 0x5
+            SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
+            #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
+            CH[:]:
+              ########################
+              # DECIMATION FILTER PAGE
+              ########################
+              DDC_EN: 0x1
+              DECIM_FACTOR: 0x0
+              DUAL_BAND_EN: 0x0
+              REAL_OUT_EN: 0x0
+              DDC0_NCO1_LSB: 0x00
+              DDC0_NCO1_MSB: 0x4e
+              DDC0_NCO2_LSB: 0x00
+              DDC0_NCO2_MSB: 0x00
+              DDC0_NCO3_LSB: 0x00
+              DDC0_NCO3_MSB: 0x00
+              DDC0_NCO4_LSB: 0x00
+              DDC0_NCO4_MSB: 0x00
+              NCO_SEL_PIN: 0x00
+              NCO_SEL: 0x00
+              LMFC_RESET_MODE: 0x00
+              DDC0_6DB_GAIN: 0x01
+              DDC1_6DB_GAIN: 0x01
+              DDC_DET_LAT: 0x5
+              WBF_6DB_GAIN: 0x01          
+              CUSTOM_PATTERN1_LSB: 0x00
+              CUSTOM_PATTERN1_MSB: 0x00
+              CUSTOM_PATTERN2_LSB: 0x00
+              CUSTOM_PATTERN2_MSB: 0x00
+              TEST_PATTERN_SEL: 0x00
+              TEST_PAT_RES: 0x00
+              TP_RES_EN: 0x00          
+              ########################
+              # JESD DIGITAL PAGE
+              ########################         
+              SCRAMBLE_EN: 0x1
+              12BIT_MODE: 0x0
+              SYNC_REG_EN: 0x0
+              SYNC_REG: 0x0          
+              RAMP_12BIT: 0x0
+              JESD_MODE0: 0x0
+              JESD_MODE1: 0x0
+              JESD_MODE2: 0x1
+              LMFC_MASK_RESET: 0x0
+              LINK_LAY_RPAT: 0x0
+              LINK_LAYER_TESTMODE: 0x0
+              40X_MODE: 0x7
+              PLL_MODE: 0x2
+              SEL_EMP_LANE0: 0x5
+              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE2: 0x5
+              SEL_EMP_LANE3: 0x3F # Unused lane
+              TX_LINK_DIS: 0x0
+              FRAME_ALIGN: 0x0
+              LANE_ALIGN: 0x0
+              TESTMODE_EN: 0x0
+              CTRL_K: 0x1
+              FRAMES_PER_MULTIFRAME: 0x1F
+        ###########################################
+        ## System Generator Configuration Registers
+        ###########################################
+        SysgenCryo:      
+          Base[:]:  
+            ScratchPad: 0xDEADBEEF
+            filterAlpha: 0x4000
+            rfEnable: 1
+            feedbackGain: 0x10
+            feedbackLimit: 0x800
+            waveformSelect: 0x0
+            toneScale: 0x2
+            dspEnable: 0x1
+            dspReset: 0x0
+            synthesisScale: 0x2
+            analysisScale: 0x2
+
+        ###########################################
+      AppTopJesd[:]:
+        JesdRx:
+          Enable: 0x3F3 # Both ADC channels
+          #Enable: 0x33  # Only using ADC[0]
+          #Enable: 0x3C0 # Only using ADC[1]
+          Polarity: 0x100
+          InvertAdcData: 0x00
+          LinkErrMask: 0x3F # Mask Enable the errors that are required to brake the link. bit 5-0: positionErr - s_bufOvf - s_bufUnf - dispErr - decErr - s_alignErr
+          ScrambleEnable: 0x1
+          ResetGTs: 0x0
+          ClearErrors: 0x0
+          InvertSync: Inverted
+          ReplaceEnable: Enabled
+          SubClass: 0x1
+          SysrefDelay: 0x0
+        JesdTx:
+          Enable: 0x3CF # Both DAC channels
+          #Enable: 0xF   # Only using DAC[0]
+          # Enable: 0x3C0 # Only using DAC[1]
+          Polarity: 0x82   # JESD1_TO_AMC appears to be inverted???
+          Loopback: 0x0
+          InvertDacData: 0x0
+          HighAmplitudeVal: 0xC000
+          LowAmplitudeVal:  0x4000
+          SquarePeriod: 0x0004
+          RampStep: 0x0001
+          ScrambleEnable: 0x1
+          TestSigEnable: 0x0
+          InvertSync: 0x0
+          ReplaceEnable: 0x1
+          SubClass: 0x1  
+          
+          dataOutMux[:]: UserData # turn off thes channels one is the new zero
+          dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
+          dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
+          # dataOutMux[0]: OutputOnes # turn off thes channels one is the new zero
+          # dataOutMux[1]: OutputOnes # Unused channel
+          # dataOutMux[2]: OutputOnes # Unused channel
+          # dataOutMux[3]: OutputOnes # Unused channel
+          dataOutMux[4]: OutputOnes # Unused channel
+          dataOutMux[5]: OutputOnes # Unused channel
+          testOutMux[:]: SquareWave
+          
+          txDiffCtrl[:]: 0xF8
+          txDiffCtrl[4]: 0x00 # Unused channel
+          txDiffCtrl[5]: 0x00 # Unused channel
+          
+          txPreCursor[:]: 0x05
+          txPreCursor[4]: 0xFF # Unused channel
+          txPreCursor[5]: 0xFF # Unused channel
+          
+          txPostCursor[:]: 0x05
+          txPostCursor[4]: 0xFF # Unused channel
+          txPostCursor[5]: 0xFF # Unused channel
+ 
+          # #############################
+          # TestSigEnable: 0x1
+          # dataOutMux[:]: TestData
+          # testOutMux[:]: SquareWave
+          # #############################
+      DaqMuxV2[:]:
+        InputMuxSel[:]: 'Disabled'
+        FormatDataWidth[:]: 'D16-bit'
+        FormatSign[:]: 'Unsigned'
+        DecimationAveraging[:]: 'Disabled'
+        PacketHeaderEn: 'Disabled'
+        TriggerHwAutoRearm: 'Disabled'
+        TriggerHwArm: '0x0'
+        TriggerCascMask: 'Disabled'
+      DacSigGen[:]:
+        EnableMask: 0x3   # Enable both channels
+        ModeMask:   0x3   # Set both channels into 'Periodic Mode'
+        SignFormat: 0x0   # Set both channels to 'Signed 2's complement' format
+        #####################################################
+        #####################################################
+        #####################################################
+        # CsvFilePath: /afs/slac.stanford.edu/u/re/ruckman/projects/lcls/cryo-det/firmware/targets/CryoCmbRtmEth/config/multitones_500_baseband.csv
+        ##CsvFilePath: /afs/slac.stanford.edu/u/rl/dandvan/cryo_det/matlab/multitone_space1p8gauss0p6MHz_b_baseband16k.csv
+        #CsvFilePath: /home/cryo/mdewart/multitone_space1p8gauss0p6MHz_b_baseband16k.csv
+        #CsvFilePath: /afs/slac/g/lcls/epics/R3-14-12-4_1-1/iocTop/users/mdewart/cryo-campus/matlab/broad_noise4_NIST.csv
+        #CsvFilePath: /u/rl/dandvan/cryo_det/matlab/broad_noise4_NIST.csv
+        #
+        # CsvFilePath: /afs/slac.stanford.edu/u/rl/dandvan/cryo_det/matlab/Is_zeros_Qs_ones.csv
+        #CsvFilePath: /afs/slac.stanford.edu/u/rl/dandvan/cryo_det/matlab/broad_noise4.csv
+        # CsvFilePath: /afs/slac.stanford.edu/u/re/ruckman/projects/lcls/cryo-det/firmware/targets/CryoCmbRtmEth/config/example_csv_2Tones_4096pts.csv
+        # CsvFilePath: /afs/slac.stanford.edu/u/re/ruckman/projects/lcls/cryo-det/firmware/targets/CryoCmbRtmEth/config/example_csv_1Tones_10MHzoffset.csv
+        # CsvFilePath: /afs/slac.stanford.edu/u/re/ruckman/projects/lcls/cryo-det/firmware/targets/CryoCmbRtmEth/config/Is_ones_Qs_ones.csv
+        # CsvFilePath: /afs/slac.stanford.edu/u/re/ruckman/projects/lcls/cryo-det/firmware/targets/CryoCmbRtmEth/config/Is_Ones_Qs_zeros.csv
+        # CsvFilePath: /afs/slac.stanford.edu/u/re/ruckman/projects/lcls/cryo-det/firmware/targets/CryoCmbRtmEth/config/Is_zeros_Qs_ones.csv
+        # CsvFilePath: /afs/slac.stanford.edu/u/re/ruckman/projects/lcls/cryo-det/firmware/targets/CryoCmbRtmEth/config/Is_zeros_Qs_zeros.csv
+        #####################################################
+        #####################################################
+        #####################################################


### PR DESCRIPTION
Adds defaults file for 2x HBs setup. It is simply a copy of the `defaults_c03_hb_none.yml` file.

https://jira.slac.stanford.edu/browse/ESCRYODET-674