### PR TITLE
Add fixes to help solve configuration issues

### DIFF
--- a/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -45,7 +45,7 @@ AMCc:
             Ctrl:
               EnableCh: 0x0
         MicrowaveMuxCore[0]:
-          enable: 'True'          
+          enable: 'True'
           PLL[0]:
             # 3.5012 GHz
             REG[0]:  0x000001C0
@@ -167,7 +167,7 @@ AMCc:
             REG[9]:  0x34337CC9
             REG[10]:  0x00C03FFA
             REG[11]:  0x61300B
-            REG[12]:  0x0001041C  
+            REG[12]:  0x0001041C
         MicrowaveMuxCore[:]:
           DBG:
             txSyncMask: 0x0    # Both DAC channels
@@ -290,12 +290,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x20F2   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -366,7 +366,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -374,7 +374,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -390,7 +390,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -425,7 +425,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -450,21 +450,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -475,7 +475,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -487,19 +487,19 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
             feedbackGain: 0x10
             feedbackLimit: 0x800
             waveformSelect: 0x0
-            toneScale: 0x2    
+            toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
             synthesisScale: 0x2
-            analysisScale: 0x2    
+            analysisScale: 0x2
             # muxSelect: SigGen
             # Ch0MuxSel: SineGen
             # Ch0B1CjEn: CH0_B1_Norm
@@ -541,8 +541,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -553,19 +553,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c02_hb_none.yml
+++ b/defaults/defaults_c02_hb_none.yml
@@ -307,17 +307,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c02_hb_none.yml
+++ b/defaults/defaults_c02_hb_none.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -77,7 +77,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 7.9988 GHz 
+            # 7.9988 GHz
             REG[0]:  0x0200200
             REG[1]:  0x08C15551
             REG[2]:  0x40032
@@ -226,12 +226,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x2072   # 16 bits, mixer on, NCO on, two's compliment data
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -302,7 +302,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -310,7 +310,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -326,7 +326,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -361,7 +361,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -386,21 +386,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -411,7 +411,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -423,8 +423,8 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
@@ -468,8 +468,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -480,19 +480,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c02_lb_lb.yml
+++ b/defaults/defaults_c02_lb_lb.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -45,7 +45,7 @@ AMCc:
             Ctrl:
               EnableCh: 0x0
         MicrowaveMuxCore[0]:
-          enable: 'True'          
+          enable: 'True'
           PLL[0]:
             # 3.5012 GHz
             REG[0]:  0x000001C0
@@ -167,7 +167,7 @@ AMCc:
             REG[9]:  0x34337CC9
             REG[10]:  0x00C03FFA
             REG[11]:  0x61300B
-            REG[12]:  0x0001041C  
+            REG[12]:  0x0001041C
         MicrowaveMuxCore[:]:
           DBG:
             txSyncMask: 0x0    # Both DAC channels
@@ -289,12 +289,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x2072   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -365,7 +365,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -373,7 +373,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -389,7 +389,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -424,7 +424,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -449,21 +449,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -474,7 +474,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -486,19 +486,19 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
             feedbackGain: 0x10
             feedbackLimit: 0x800
             waveformSelect: 0x0
-            toneScale: 0x2    
+            toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
             synthesisScale: 0x2
-            analysisScale: 0x2    
+            analysisScale: 0x2
             # muxSelect: SigGen
             # Ch0MuxSel: SineGen
             # Ch0B1CjEn: CH0_B1_Norm
@@ -540,8 +540,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -552,19 +552,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c02_lb_lb.yml
+++ b/defaults/defaults_c02_lb_lb.yml
@@ -370,17 +370,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c02_lb_none.yml
+++ b/defaults/defaults_c02_lb_none.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -62,7 +62,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[1]:
-            # 4.0012 GHz  
+            # 4.0012 GHz
             REG[0]:  0x00000200
             REG[1]:  0x08FD5551
             REG[2]:  0x40032
@@ -77,7 +77,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 5.9988 GHz  
+            # 5.9988 GHz
             REG[0]:  0x00200300
             REG[1]:  0xD180001
             REG[2]:  0x12
@@ -92,7 +92,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[3]:
-            # 6.4988 GHz  
+            # 6.4988 GHz
             REG[0]:  0x00200340
             REG[1]:  0xE32AAA1
             REG[2]:  0x80032
@@ -227,12 +227,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x2072   # 16 bits, mixer on, NCO on, two's compliment data
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -303,7 +303,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -311,7 +311,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -327,7 +327,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -362,7 +362,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -387,21 +387,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -412,7 +412,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -424,8 +424,8 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
@@ -469,8 +469,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -481,19 +481,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c02_lb_none.yml
+++ b/defaults/defaults_c02_lb_none.yml
@@ -308,17 +308,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c02_lb_none_CPlow.yml
+++ b/defaults/defaults_c02_lb_none_CPlow.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -62,7 +62,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[1]:
-            # 4.0012 GHz  
+            # 4.0012 GHz
             REG[0]:  0x00000200
             REG[1]:  0x08FD5551
             REG[2]:  0x40032
@@ -77,7 +77,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 5.9988 GHz  
+            # 5.9988 GHz
             REG[0]:  0x00200300
             REG[1]:  0xD180001
             REG[2]:  0x12
@@ -92,7 +92,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[3]:
-            # 6.4988 GHz  
+            # 6.4988 GHz
             REG[0]:  0x00200340
             REG[1]:  0xE32AAA1
             REG[2]:  0x80032
@@ -227,12 +227,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x2072   # 16 bits, mixer on, NCO on, two's compliment data
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -303,7 +303,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -311,7 +311,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -327,7 +327,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -362,7 +362,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -387,21 +387,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -412,7 +412,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -424,8 +424,8 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
@@ -469,8 +469,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -481,19 +481,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c02_lb_none_CPlow.yml
+++ b/defaults/defaults_c02_lb_none_CPlow.yml
@@ -308,17 +308,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c02_lb_none_fixed.yml
+++ b/defaults/defaults_c02_lb_none_fixed.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -62,7 +62,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[1]:
-            # 4.0012 GHz  
+            # 4.0012 GHz
             REG[0]:  0x00000200
             REG[1]:  0x08FD5551
             REG[2]:  0x40032
@@ -77,7 +77,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 5.9988 GHz  
+            # 5.9988 GHz
             REG[0]:  0x00200300
             REG[1]:  0xD180001
             REG[2]:  0x12
@@ -92,7 +92,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[3]:
-            # 6.4988 GHz  
+            # 6.4988 GHz
             REG[0]:  0x00200340
             REG[1]:  0xE32AAA1
             REG[2]:  0x80032
@@ -227,12 +227,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x2072   # 16 bits, mixer on, NCO on, two's compliment data
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -303,7 +303,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -311,7 +311,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -327,7 +327,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -362,7 +362,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -387,21 +387,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -412,7 +412,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -424,8 +424,8 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
@@ -469,8 +469,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -481,19 +481,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c02_lb_none_fixed.yml
+++ b/defaults/defaults_c02_lb_none_fixed.yml
@@ -308,17 +308,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c03_hb_hb.yml
+++ b/defaults/defaults_c03_hb_hb.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -77,7 +77,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 7.9988 GHz 
+            # 7.9988 GHz
             REG[0]:  0x0200200
             REG[1]:  0x08C15551
             REG[2]:  0x40032
@@ -227,12 +227,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x20F2   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -303,7 +303,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -311,7 +311,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -327,7 +327,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -362,7 +362,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -387,21 +387,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -412,7 +412,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -424,8 +424,8 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
@@ -469,8 +469,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -481,19 +481,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c03_hb_hb.yml
+++ b/defaults/defaults_c03_hb_hb.yml
@@ -308,17 +308,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c03_hb_lb.yml
+++ b/defaults/defaults_c03_hb_lb.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -45,7 +45,7 @@ AMCc:
             Ctrl:
               EnableCh: 0x0
         MicrowaveMuxCore[0]:
-          enable: 'True'          
+          enable: 'True'
           PLL[0]:
             # 5.5012 GHz
             REG[0]:  0x000002C0
@@ -77,7 +77,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 7.9988 GHz 
+            # 7.9988 GHz
             REG[0]:  0x0200200
             REG[1]:  0x08C15551
             REG[2]:  0x40032
@@ -107,7 +107,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
         MicrowaveMuxCore[1]:
-          enable: 'True'          
+          enable: 'True'
           PLL[0]:
             # 3.5012 GHz
             REG[0]:  0x000001C0
@@ -167,7 +167,7 @@ AMCc:
             REG[9]:  0x34337CC9
             REG[10]:  0x00C03FFA
             REG[11]:  0x61300B
-            REG[12]:  0x0001041C    
+            REG[12]:  0x0001041C
         MicrowaveMuxCore[:]:
           DBG:
             txSyncMask: 0x0    # Both DAC channels
@@ -290,12 +290,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x20F2   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -366,7 +366,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -374,7 +374,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -390,7 +390,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -425,7 +425,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -450,21 +450,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -475,7 +475,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -487,19 +487,19 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
             feedbackGain: 0x10
             feedbackLimit: 0x800
             waveformSelect: 0x0
-            toneScale: 0x2    
+            toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
             synthesisScale: 0x2
-            analysisScale: 0x2    
+            analysisScale: 0x2
             # muxSelect: SigGen
             # Ch0MuxSel: SineGen
             # Ch0B1CjEn: CH0_B1_Norm
@@ -541,8 +541,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -553,19 +553,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c03_hb_lb.yml
+++ b/defaults/defaults_c03_hb_lb.yml
@@ -371,17 +371,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c03_hb_none.yml
+++ b/defaults/defaults_c03_hb_none.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -77,7 +77,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 7.9988 GHz 
+            # 7.9988 GHz
             REG[0]:  0x0200200
             REG[1]:  0x08C15551
             REG[2]:  0x40032
@@ -227,12 +227,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x20F2   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -303,7 +303,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -311,7 +311,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -327,7 +327,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -362,7 +362,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -387,21 +387,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -412,7 +412,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -424,8 +424,8 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
@@ -469,8 +469,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -481,19 +481,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c03_hb_none.yml
+++ b/defaults/defaults_c03_hb_none.yml
@@ -308,17 +308,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c03_lb_hb.yml
+++ b/defaults/defaults_c03_lb_hb.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -45,7 +45,7 @@ AMCc:
             Ctrl:
               EnableCh: 0x0
         MicrowaveMuxCore[0]:
-          enable: 'True'          
+          enable: 'True'
           PLL[0]:
             # 3.5012 GHz
             REG[0]:  0x000001C0
@@ -107,7 +107,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
         MicrowaveMuxCore[1]:
-          enable: 'True'          
+          enable: 'True'
           PLL[0]:
             # 5.5012 GHz
             REG[0]:  0x000002C0
@@ -139,7 +139,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 7.9988 GHz 
+            # 7.9988 GHz
             REG[0]:  0x0200200
             REG[1]:  0x08C15551
             REG[2]:  0x40032
@@ -290,12 +290,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x20F2   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -366,7 +366,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -374,7 +374,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -390,7 +390,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -425,7 +425,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -450,21 +450,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -475,7 +475,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -487,19 +487,19 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
             feedbackGain: 0x10
             feedbackLimit: 0x800
             waveformSelect: 0x0
-            toneScale: 0x2    
+            toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
             synthesisScale: 0x2
-            analysisScale: 0x2    
+            analysisScale: 0x2
             # muxSelect: SigGen
             # Ch0MuxSel: SineGen
             # Ch0B1CjEn: CH0_B1_Norm
@@ -541,8 +541,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -553,19 +553,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c03_lb_hb.yml
+++ b/defaults/defaults_c03_lb_hb.yml
@@ -371,17 +371,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c03_lb_lb.yml
+++ b/defaults/defaults_c03_lb_lb.yml
@@ -311,17 +311,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000

--- a/defaults/defaults_c03_lb_lb.yml
+++ b/defaults/defaults_c03_lb_lb.yml
@@ -38,7 +38,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -65,7 +65,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[1]:
-            # 4.0012 GHz  
+            # 4.0012 GHz
             REG[0]:  0x00000200
             REG[1]:  0x08FD5551
             REG[2]:  0x40032
@@ -80,7 +80,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 5.9988 GHz  
+            # 5.9988 GHz
             REG[0]:  0x00200300
             REG[1]:  0xD180001
             REG[2]:  0x12
@@ -95,7 +95,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[3]:
-            # 6.4988 GHz  
+            # 6.4988 GHz
             REG[0]:  0x00200340
             REG[1]:  0xE32AAA1
             REG[2]:  0x80032
@@ -230,12 +230,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x20F2   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -306,7 +306,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -330,7 +330,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -365,7 +365,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -390,21 +390,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -415,7 +415,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -427,8 +427,8 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
@@ -472,8 +472,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -484,19 +484,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c03_lb_none.yml
+++ b/defaults/defaults_c03_lb_none.yml
@@ -35,7 +35,7 @@ AMCc:
         OutputConfig[0]: 0x0
         OutputConfig[1]: 0x0
         OutputConfig[2]: 0x1
-        OutputConfig[3]: 0x1    
+        OutputConfig[3]: 0x1
     AppTop:
       AppCore:
         RtmCryoDet:
@@ -62,7 +62,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[1]:
-            # 4.0012 GHz  
+            # 4.0012 GHz
             REG[0]:  0x00000200
             REG[1]:  0x08FD5551
             REG[2]:  0x40032
@@ -77,7 +77,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[2]:
-            # 5.9988 GHz  
+            # 5.9988 GHz
             REG[0]:  0x00200300
             REG[1]:  0xD180001
             REG[2]:  0x12
@@ -92,7 +92,7 @@ AMCc:
             REG[11]:  0x61300B
             REG[12]:  0x0001041C
           PLL[3]:
-            # 6.4988 GHz  
+            # 6.4988 GHz
             REG[0]:  0x00200340
             REG[1]:  0xE32AAA1
             REG[2]:  0x80032
@@ -228,12 +228,12 @@ AMCc:
             LmkReg_0x016B: 0x00
           DAC[:]:
             DacReg[0]: 0x0218   # Sets board to 4X interpolation (Default: 0x0218)
-            DacReg[1]: 0x0003   
+            DacReg[1]: 0x0003
             DacReg[2]: 0x20F2   # 16 bits, mixer on, NCO on, two's compliment data, 4-wire SPI
-            DacReg[3]: 0xF300   
+            DacReg[3]: 0xF300
             DacReg[4]: 0xF0F0   # This masks lanes 7,6,5,4 fifo and lane errors.  Uros had it masking lanes 7,6,5,4,3,2 because this was for the demo board that only had two lanes I think.
             DacReg[5]: 0xFF07   # Not sure here.  This is masking some sysref errors, Uros had it only masking serdes block 0 and 1 PLL locks and the DAC PLL lock alarm
-            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms 
+            DacReg[6]: 0xFFFF   # Set as eval board, is making a bunch of alarms
             DacReg[7]: 0x3800
             DacReg[8]: 0x0000
             DacReg[9]: 0x0000
@@ -304,7 +304,7 @@ AMCc:
             DacReg[73]: 0x0000  # JESD Link selection.  Seems it should be set like the eval board.
             DacReg[74]: 0x0f01  # Turns on serdes 0-3 and does NOT reset JESD reset.
             DacReg[75]: 0x0801  # Number of octates per frame (1) and elastic buffers as set on eval board
-            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.  
+            DacReg[76]: 0x1F03  # Number of JESD lanes being use (3 - means 4) and 32 frames per multifame.
             DacReg[77]: 0x0300  # Number of converters per link - 4
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
@@ -312,7 +312,7 @@ AMCc:
             DacReg[81]: 0x0026  # sync_request_ena_link0
             DacReg[82]: 0x0026  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1  
+            DacReg[84]: 0x0026  # sync_request_ena_link1
             DacReg[85]: 0x0026  # error_ena_link1
             DacReg[86]: 0x0000
             DacReg[87]: 0x0026  # sync_request_ena_link2
@@ -328,7 +328,7 @@ AMCc:
             DacReg[97]: 0x0211
             DacReg[98]: 0x0000
             DacReg[99]: 0x0000
-            DacReg[100]: 0x0 # write to clear alarms 
+            DacReg[100]: 0x0 # write to clear alarms
             DacReg[101]: 0x0 # write to clear alarms0
             DacReg[102]: 0x0 # write to clear alarms0
             DacReg[103]: 0x0 # write to clear alarms0
@@ -363,7 +363,7 @@ AMCc:
             SYSREF_DEL_HI: 0x0
             SYSREF_DEL_LO: 0x5
             SLOW_SP_EN1: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
-            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS       
+            SLOW_SP_EN2: 0x1 # 0x1 = ADC sampling rates are slower than 2.5 GSPS
             JESD_OUTPUT_SWING: 0x4 # 0x4 = 960 mVPP (max. swing)
             #JESD_OUTPUT_SWING: 0x6 # 0x6 = 905 mVPP
             CH[:]:
@@ -388,21 +388,21 @@ AMCc:
               DDC0_6DB_GAIN: 0x01
               DDC1_6DB_GAIN: 0x01
               DDC_DET_LAT: 0x5
-              WBF_6DB_GAIN: 0x01          
+              WBF_6DB_GAIN: 0x01
               CUSTOM_PATTERN1_LSB: 0x00
               CUSTOM_PATTERN1_MSB: 0x00
               CUSTOM_PATTERN2_LSB: 0x00
               CUSTOM_PATTERN2_MSB: 0x00
               TEST_PATTERN_SEL: 0x00
               TEST_PAT_RES: 0x00
-              TP_RES_EN: 0x00          
+              TP_RES_EN: 0x00
               ########################
               # JESD DIGITAL PAGE
-              ########################         
+              ########################
               SCRAMBLE_EN: 0x1
               12BIT_MODE: 0x0
               SYNC_REG_EN: 0x0
-              SYNC_REG: 0x0          
+              SYNC_REG: 0x0
               RAMP_12BIT: 0x0
               JESD_MODE0: 0x0
               JESD_MODE1: 0x0
@@ -413,7 +413,7 @@ AMCc:
               40X_MODE: 0x7
               PLL_MODE: 0x2
               SEL_EMP_LANE0: 0x5
-              SEL_EMP_LANE1: 0x3F # Unused lane 
+              SEL_EMP_LANE1: 0x3F # Unused lane
               SEL_EMP_LANE2: 0x5
               SEL_EMP_LANE3: 0x3F # Unused lane
               TX_LINK_DIS: 0x0
@@ -425,8 +425,8 @@ AMCc:
         ###########################################
         ## System Generator Configuration Registers
         ###########################################
-        SysgenCryo:      
-          Base[:]:  
+        SysgenCryo:
+          Base[:]:
             ScratchPad: 0xDEADBEEF
             filterAlpha: 0x4000
             rfEnable: 1
@@ -470,8 +470,8 @@ AMCc:
           TestSigEnable: 0x0
           InvertSync: 0x0
           ReplaceEnable: 0x1
-          SubClass: 0x1  
-          
+          SubClass: 0x1
+
           dataOutMux[:]: UserData # turn off thes channels one is the new zero
           dataOutMux[4]: OutputOnes # turn off thes channels one is the new zero
           dataOutMux[5]: OutputOnes # turn off thes channels one is the new zero
@@ -482,19 +482,19 @@ AMCc:
           dataOutMux[4]: OutputOnes # Unused channel
           dataOutMux[5]: OutputOnes # Unused channel
           testOutMux[:]: SquareWave
-          
+
           txDiffCtrl[:]: 0xF8
           txDiffCtrl[4]: 0x00 # Unused channel
           txDiffCtrl[5]: 0x00 # Unused channel
-          
+
           txPreCursor[:]: 0x05
           txPreCursor[4]: 0xFF # Unused channel
           txPreCursor[5]: 0xFF # Unused channel
-          
+
           txPostCursor[:]: 0x05
           txPostCursor[4]: 0xFF # Unused channel
           txPostCursor[5]: 0xFF # Unused channel
- 
+
           # #############################
           # TestSigEnable: 0x1
           # dataOutMux[:]: TestData

--- a/defaults/defaults_c03_lb_none.yml
+++ b/defaults/defaults_c03_lb_none.yml
@@ -309,17 +309,17 @@ AMCc:
             DacReg[78]: 0x0f2f  # Enable scrambler
             DacReg[79]: 0x1c61
             DacReg[80]: 0x0000
-            DacReg[81]: 0x0026  # sync_request_ena_link0
-            DacReg[82]: 0x0026  # error_ena_link0
+            DacReg[81]: 0x00c7  # sync_request_ena_link0
+            DacReg[82]: 0x00c7  # error_ena_link0
             DacReg[83]: 0x0000
-            DacReg[84]: 0x0026  # sync_request_ena_link1
-            DacReg[85]: 0x0026  # error_ena_link1
+            DacReg[84]: 0x00c7  # sync_request_ena_link1
+            DacReg[85]: 0x00c7  # error_ena_link1
             DacReg[86]: 0x0000
-            DacReg[87]: 0x0026  # sync_request_ena_link2
-            DacReg[88]: 0x0026  # error_ena_link2
+            DacReg[87]: 0x00c7  # sync_request_ena_link2
+            DacReg[88]: 0x00c7  # error_ena_link2
             DacReg[89]: 0x0000
-            DacReg[90]: 0x0026  # sync_request_ena_link3
-            DacReg[91]: 0x0026  # error_ena_link3
+            DacReg[90]: 0x00c7  # sync_request_ena_link3
+            DacReg[91]: 0x00c7  # error_ena_link3
             DacReg[92]: 0x5555  # Skip 2 then use only the next sysref
             DacReg[93]: 0x0000
             DacReg[94]: 0x0000


### PR DESCRIPTION
This PR changes the DAC resync conditions from `0x26` to `0xc7` as suggested by Larry. Larry said these were probably legacy configuration when we still had mode signal integrity in the JESD lanes and we relaxed those conditions.

We used these new setting while solving [ESCRYODET-667](https://jira.slac.stanford.edu/browse/ESCRYODET-667).