### PR TITLE
Changing synthesisScale from 0x2 to 0x1 to fix DAC saturation 100+ tones.

### DIFF
--- a/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
+++ b/defaults/2019_06_04_Dual_Band_AMC_Config_LBx2.yml
@@ -498,7 +498,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
             # muxSelect: SigGen
             # Ch0MuxSel: SineGen

--- a/defaults/defaults_c02_hb_none.yml
+++ b/defaults/defaults_c02_hb_none.yml
@@ -458,7 +458,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################

--- a/defaults/defaults_c02_lb_lb.yml
+++ b/defaults/defaults_c02_lb_lb.yml
@@ -521,7 +521,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
             # muxSelect: SigGen
             # Ch0MuxSel: SineGen

--- a/defaults/defaults_c02_lb_none.yml
+++ b/defaults/defaults_c02_lb_none.yml
@@ -459,7 +459,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################

--- a/defaults/defaults_c02_lb_none_CPlow.yml
+++ b/defaults/defaults_c02_lb_none_CPlow.yml
@@ -459,7 +459,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################

--- a/defaults/defaults_c02_lb_none_fixed.yml
+++ b/defaults/defaults_c02_lb_none_fixed.yml
@@ -459,7 +459,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################

--- a/defaults/defaults_c03_hb_hb.yml
+++ b/defaults/defaults_c03_hb_hb.yml
@@ -459,7 +459,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################

--- a/defaults/defaults_c03_hb_lb.yml
+++ b/defaults/defaults_c03_hb_lb.yml
@@ -522,7 +522,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
             # muxSelect: SigGen
             # Ch0MuxSel: SineGen

--- a/defaults/defaults_c03_hb_none.yml
+++ b/defaults/defaults_c03_hb_none.yml
@@ -459,7 +459,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################

--- a/defaults/defaults_c03_lb_hb.yml
+++ b/defaults/defaults_c03_lb_hb.yml
@@ -522,7 +522,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
             # muxSelect: SigGen
             # Ch0MuxSel: SineGen

--- a/defaults/defaults_c03_lb_lb.yml
+++ b/defaults/defaults_c03_lb_lb.yml
@@ -462,7 +462,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################

--- a/defaults/defaults_c03_lb_none.yml
+++ b/defaults/defaults_c03_lb_none.yml
@@ -460,7 +460,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################

--- a/defaults/defaults_tkid.yml
+++ b/defaults/defaults_tkid.yml
@@ -435,7 +435,7 @@ AMCc:
             toneScale: 0x2
             dspEnable: 0x1
             dspReset: 0x0
-            synthesisScale: 0x2
+            synthesisScale: 0x1
             analysisScale: 0x2
 
         ###########################################


### PR DESCRIPTION
Resolves issue https://github.com/slaclab/smurf_cfg/issues/11 - see there for more details.  

Changes synthesisScale from 0x2 to 0x1.  Each increment of synthesisScale corresponds to 6dB of tone power.  Lower synthesisScale results in lower tone power, and higher synthesisScale results in higher tone power.  Here's the measured correspondence for a single tone out of a LB AMC at 4.25GHz;

synthesisScale=0x0 -> -40dBm
synthesisScale=0x1 -> -34dBm
synthesisScale=0x2 -> -28dBm

In newer software releases, tone power with synthesisScale=0x2 is too high to run with 100 or so tones or more - the DAC saturates.  Still investigating cause (possibly a rogue/configuration issue?) but this PR reduces synthesisScale to 0x1 which should fix the reported issue.